### PR TITLE
Ansible 2.9 compatibility

### DIFF
--- a/roles/php/common/tasks/main.yml
+++ b/roles/php/common/tasks/main.yml
@@ -96,7 +96,7 @@
     src=/etc/php.ini
     dest=/etc/php/5.6/cli/php.ini
     state=link
-  when: (ansible_os_family == "Debian") and (php_result|changed)
+  when: (ansible_os_family == "Debian") and (php_result is changed)
   tags:
     - nginx
 

--- a/roles/php/fpm/tasks/main.yml
+++ b/roles/php/fpm/tasks/main.yml
@@ -40,7 +40,7 @@
     src=/etc/php.ini
     dest=/etc/php/5.6/fpm/php.ini
     state=link
-  when: (ansible_os_family == "Debian") and (php_result|changed)
+  when: (ansible_os_family == "Debian") and (php_result is changed)
   tags:
     - php
 

--- a/roles/php7/fpm/tasks/main.yml
+++ b/roles/php7/fpm/tasks/main.yml
@@ -39,7 +39,7 @@
     src=/etc/php.ini
     dest=/etc/php/7.1/fpm/php.ini
     state=link
-  when: (ansible_os_family == "Debian") and (php_result|changed)
+  when: (ansible_os_family == "Debian") and (php_result is changed)
   tags:
     - php
 


### PR DESCRIPTION
In Ansible 2.9 Jinja tests can no longer be used as filters. This PR corrects the places were that deprecated syntax was being used.

Fixes issue #20