### PR TITLE
fix incorrect parsing of action arguments in cscart role

### DIFF
--- a/roles/cscart/tasks/db.yml
+++ b/roles/cscart/tasks/db.yml
@@ -37,7 +37,7 @@
 - name: granting users privileges (automatically)
   mysql_user:
     name={{ item.key|replace('.', '_') }}
-    password= "{{ lookup('password', playbook_dir + '/credentials/databases/' + item.key.replace('.', '_') + ' chars=ascii_letters,digits length=16') }}"
+    password="{{ lookup('password', playbook_dir + '/credentials/databases/' + item.key.replace('.', '_') + ' chars=ascii_letters,digits length=16') }}"
     priv={{ item.key|replace('.', '_') }}.*:ALL
     login_user=root
     login_password={{ mysql.password }}


### PR DESCRIPTION
The additional space after the `=` sign caused Ansible to parse the argument dict incorrectly as follows:
```
{
  "password": "",
  "{{ lookup('password', playbook_dir + '/credentials/databases/' + item.key.replace('.', '_') + ' chars": "ascii_letters,digits length=16') }}",
}
```
This would cause the task to fail due to an unrecognised argument. This at least happens on Ansible core 2.13.6 and likely earlier versions too. The fix should maintain backwards compatibility.

Just out of interest: Why are you using `=` for action arguments instead of `:`?